### PR TITLE
fix(reload): ensure daemon starts, even if reload not required

### DIFF
--- a/agents/onionbalance/onionbalancedaemon/daemon.go
+++ b/agents/onionbalance/onionbalancedaemon/daemon.go
@@ -43,13 +43,25 @@ func (t *OnionBalance) Start() {
 	}()
 }
 
+func (t *OnionBalance) IsRunning() bool {
+	return t.cmd != nil && (t.cmd.ProcessState == nil || !t.cmd.ProcessState.Exited())
+}
+
+func (t *OnionBalance) EnsureRunning() {
+	if !t.IsRunning() {
+		fmt.Println("onionbalance is not running...")
+		t.Start()
+	}
+}
+
 func (t *OnionBalance) Reload() {
 	fmt.Println("reloading onionbalance...")
 
-	// start if not already running
-	if t.cmd == nil || (t.cmd.ProcessState != nil && t.cmd.ProcessState.Exited()) {
-		t.Start()
-	} else {
+	if t.IsRunning() {
+		fmt.Println("stopping existing onionbalance...")
 		t.cmd.Process.Signal(syscall.SIGHUP)
+		t.cmd.Wait()
 	}
+
+	t.Start()
 }


### PR DESCRIPTION
I think I found the cause of #28 

**Problem:**
Calling `daemon.Reload()` within the `sync` handler is the only place that the `onionbalance` service gets launched.  The handler only calls "daemon.Reload()" when the configuration file (`/run/onionbalance/config.yaml`) doesn't exist yet or has changed.  

On a fully clean start, this file doesn't exist yet, so the daemon does get started correctly.  However, if the container restarts within the pod (but the pod itself isn't re-created), the `config.yaml` already exists, and so the daemon does not get started.

**Solution:**
This PR fixes this by adding an additional method "EnsureRunning()" which will start the daemon if it's not already running.

I also added small changes for:
1.  the "Reload" method wasn't implemented quite right, if the service was already running, it just called `SIGHUP`, but never called start again.
2. minor refactor to remove the need for the "reload" variable, as it didn't seem necessary


**Other considerations:**
I noticed that the standard `tor` service (`/agents/tor/local`) also has similar logic around reload/start, so there may be a similar issue there that would be worth investigating.


Let me know if there are any changes/improvements I can add to his PR.