### PR TITLE
fix(onionbalance): set alpine version to fix deprecated cryptography dependency

### DIFF
--- a/Dockerfile.tor-onionbalance-manager
+++ b/Dockerfile.tor-onionbalance-manager
@@ -9,7 +9,7 @@ RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /out/onionbalance-local-manager ./agents/onionbalance/main.go
 
-FROM alpine:latest
+FROM alpine:3.16.2
 
 ARG VERSION=0.2.2
 


### PR DESCRIPTION
Until the upstream `onionbalance` or `stem` packages resolve the issue with `int_from_bytes` being removed (https://github.com/torproject/stem/issues/118), this could be a temporary fix for #30 

