### PR TITLE
Update onibalancer image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.17-alpine as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.17 as builder
 
 WORKDIR /src
 
@@ -8,13 +8,14 @@ ARG TARGETOS TARGETARCH
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /out/manager main.go
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags="-s -w" -o /out/manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY --from=builder /out/manager .
+
+COPY --from=builder /out/manager /
+
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.17 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20 as builder
 
 WORKDIR /src
 

--- a/Dockerfile.tor-daemon-manager
+++ b/Dockerfile.tor-daemon-manager
@@ -1,7 +1,7 @@
 ARG TOR_VERSION="0.4.7.13"
 ARG TOR_IMAGE="quay.io/bugfest/tor"
 
-FROM --platform=$BUILDPLATFORM golang:1.17 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.17 as builder
 
 WORKDIR /src
 
@@ -10,7 +10,7 @@ ARG TARGETOS TARGETARCH
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /out/tor-local-manager ./agents/tor/main.go
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags="-s -w" -o /out/tor-local-manager ./agents/tor/main.go
 
 FROM ${TOR_IMAGE}:${TOR_VERSION} as tor
 

--- a/Dockerfile.tor-daemon-manager
+++ b/Dockerfile.tor-daemon-manager
@@ -1,7 +1,7 @@
 ARG TOR_VERSION="0.4.7.13"
 ARG TOR_IMAGE="quay.io/bugfest/tor"
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.17 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20 as builder
 
 WORKDIR /src
 

--- a/Dockerfile.tor-onionbalance-manager
+++ b/Dockerfile.tor-onionbalance-manager
@@ -7,7 +7,7 @@ ARG TARGETOS TARGETARCH
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /out/onionbalance-local-manager ./agents/onionbalance/main.go
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags="-s -w" -o /out/onionbalance-local-manager ./agents/onionbalance/main.go
 
 FROM docker.io/library/alpine:3.17.3
 

--- a/Dockerfile.tor-onionbalance-manager
+++ b/Dockerfile.tor-onionbalance-manager
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.17  as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20  as builder
 
 WORKDIR /src
 

--- a/Dockerfile.tor-onionbalance-manager
+++ b/Dockerfile.tor-onionbalance-manager
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.17 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.17  as builder
 
 WORKDIR /src
 
@@ -9,14 +9,20 @@ RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -o /out/onionbalance-local-manager ./agents/onionbalance/main.go
 
-FROM alpine:3.16.2
+FROM docker.io/library/alpine:3.17.3
 
 ARG VERSION=0.2.2
 
-RUN apk add --update git python3 py3-pip py3-wheel py3-cryptography py3-setproctitle py3-pycryptodomex
-RUN python3 -m pip install git+https://gitlab.torproject.org/tpo/core/onionbalance.git@${VERSION}
+RUN apk add --no-cache --update \
+        git=2.38.4-r1 \
+        py3-cryptography=38.0.3-r1 \
+        py3-pip=22.3.1-r1 \
+        py3-pycryptodomex=3.15.0-r0 \
+        py3-setproctitle=1.3.1-r0 \
+        py3-wheel=0.38.4-r0 \
+        python3=3.10.11-r0 \
+    && python3 -m pip install --no-cache-dir git+https://gitlab.torproject.org/tpo/core/onionbalance.git@${VERSION}
 
-COPY --from=builder /out/onionbalance-local-manager .
+COPY --from=builder /out/onionbalance-local-manager /
 
-# ENTRYPOINT ["/usr/bin/onionbalance"]
-ENTRYPOINT ["./onionbalance-local-manager"]
+ENTRYPOINT ["/onionbalance-local-manager"]


### PR DESCRIPTION
A few improvements, including:

- no cache for apk and pip
- versions pin
- repo pin
- relative path removed
- remove debug info from binary

Also, I can suggest to bump go version to 1.20