### PR TITLE
Update tor version to 0.4.8.7

### DIFF
--- a/Dockerfile.tor-daemon
+++ b/Dockerfile.tor-daemon
@@ -1,4 +1,4 @@
-ARG TOR_VERSION="0.4.7.13"
+ARG TOR_VERSION="0.4.8.7"
 ARG TOR_IMAGE="quay.io/bugfest/tor"
 
 FROM ${TOR_IMAGE}:${TOR_VERSION} as tor

--- a/Dockerfile.tor-daemon-manager
+++ b/Dockerfile.tor-daemon-manager
@@ -1,4 +1,4 @@
-ARG TOR_VERSION="0.4.7.13"
+ARG TOR_VERSION="0.4.8.7"
 ARG TOR_IMAGE="quay.io/bugfest/tor"
 
 FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.20 as builder


### PR DESCRIPTION
In the new version of the tor project, anti DOS protection has been implemented see: https://community.torproject.org/onion-services/advanced/dos/
This is an essential feature 

Great project thanks for keeping it going


https://github.com/bugfest/tor-docker/pull/6



