### PR TITLE
fix/tor-instances: Tor instances missing volume and configs

### DIFF
--- a/controllers/tor/tor_configmap.go
+++ b/controllers/tor/tor_configmap.go
@@ -36,6 +36,7 @@ import (
 
 const torConfigFormat = `# Config automatically generated
 # {{ .Tor.Namespace }}/{{ .Tor.Name }}
+DataDirectory /var/lib/tor/data
 
 {{- if .Tor.Spec.Client.DNS.Enable }}
 # Client:DNS

--- a/controllers/tor/tor_deployment.go
+++ b/controllers/tor/tor_deployment.go
@@ -98,11 +98,21 @@ func torDeployment(tor *torv1alpha2.Tor, projectConfig *configv2.ProjectConfig) 
 	}
 
 	torConfigMountDir := "/run/tor"
+	torServiceMountDir := "/run/tor/service"
+	torDataMountDir := "/var/lib/tor"
 
 	torVolumeMounts := []corev1.VolumeMount{
 		{
 			Name:      torConfigVolume,
 			MountPath: torConfigMountDir,
+		},
+		{
+			Name:      torServiceVolume,
+			MountPath: torServiceMountDir,
+		},
+		{
+			Name:      torDataVolume,
+			MountPath: torDataMountDir,
 		},
 	}
 
@@ -124,6 +134,18 @@ func torDeployment(tor *torv1alpha2.Tor, projectConfig *configv2.ProjectConfig) 
 						Path: "torfile",
 					}},
 				},
+			},
+		},
+		{
+			Name: torServiceVolume,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: torDataVolume,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
 	}

--- a/controllers/tor/util.go
+++ b/controllers/tor/util.go
@@ -46,6 +46,8 @@ const (
 	privateKeyVolume         = "private-key"
 	authorizedClientsVolume  = "authorized-clients"
 	torConfigVolume          = "tor-config"
+	torDataVolume            = "tor-data"
+	torServiceVolume         = "tor-service"
 	torConfigExtraVolume     = "tor-config-extra"
 	obConfigVolume           = "ob-config"
 	onionBalanceConfigVolume = "onionbalance-config"


### PR DESCRIPTION
This PR adds volume definitions and mounts for Tor instances:

- Service dir: `/run/tor/service`
- Data dir: `/var/lib/tor`

Adds config parameter `DataDirectory` (set to `/var/lib/tor`) in `/run/tor/torfile`

Fixes #67